### PR TITLE
add color to multiqc report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Initial release of nf-core/datasync, created with the [nf-core](https://nf-co.re
 
 ### `Added`
 
+- [[#31](https://github.com/nf-core/datasync/pull/31)] - Add colors to multiqc results and display first errors in tables ([@atrigila](https://github.com/atrigila), review by [@delfiterradas](https://github.com/delfiterradas)).
 - [[#31](https://github.com/nf-core/datasync/pull/31)] - Compute checksum for each input file ([@delfiterradas](https://github.com/delfiterradas), review by [@atrigila](https://github.com/atrigila)).
 - [[#35](https://github.com/nf-core/datasync/pull/35)] - Compare generated checksum to given checksum in input and update test profiles ([@delfiterradas](https://github.com/delfiterradas), review by [@atrigila](https://github.com/atrigila)).
 - [[#46](https://github.com/nf-core/datasync/pull/46)] - Import Rclone module from nf-core([@antoniasaracco](https://github.com/antoniasaracco), review by [@delfiterradas](https://github.com/delfiterradas)).

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -36,24 +36,129 @@ custom_data:
     description: "Comparison of the expected MD5 checksums provided in the samplesheet with the observed MD5 checksums of the file(s) found at the specified source path."
     plot_type: "table"
     file_format: "tsv"
+    headers:
+      Status:
+        title: Result
+        description: "= Match; - Missing in source; + Missing in destination; * Mismatch; ! Error"
+        cond_formatting_rules:
+          match:
+            - s_eq: "="
+            - s_eq: "Match"
+          missing_source:
+            - s_eq: "-"
+            - s_eq: "Missing in source"
+          missing_destination:
+            - s_eq: "+"
+            - s_eq: "Missing in destination"
+          mismatch:
+            - s_eq: "*"
+            - s_eq: "Mismatch"
+          error:
+            - s_eq: "!"
+            - s_eq: "Error"
+        cond_formatting_colours:
+          - match: "#5cb85c"
+          - missing_source: "#f0ad4e"
+          - missing_destination: "#5bc0de"
+          - mismatch: "#d9534f"
+          - error: "#8b0000"
+      File:
+        title: File
+        description: "File checked by rclone"
+      Priority:
+        title: Priority
+        hidden: true
     pconfig:
       no_violin: true
+      defaultsort:
+        - column: Priority
+          direction: asc
 
   rclone_checksum_sha:
     section_name: "SHAsum Input Validation"
     description: "Comparison of the expected SHA-256 checksums provided in the samplesheet with the observed SHA-256 checksums of the file(s) found at the specified source path."
     plot_type: "table"
     file_format: "tsv"
+    headers:
+      Status:
+        title: Result
+        description: "= Match; - Missing in source; + Missing in destination; * Mismatch; ! Error"
+        cond_formatting_rules:
+          match:
+            - s_eq: "="
+            - s_eq: "Match"
+          missing_source:
+            - s_eq: "-"
+            - s_eq: "Missing in source"
+          missing_destination:
+            - s_eq: "+"
+            - s_eq: "Missing in destination"
+          mismatch:
+            - s_eq: "*"
+            - s_eq: "Mismatch"
+          error:
+            - s_eq: "!"
+            - s_eq: "Error"
+        cond_formatting_colours:
+          - match: "#5cb85c"
+          - missing_source: "#f0ad4e"
+          - missing_destination: "#5bc0de"
+          - mismatch: "#d9534f"
+          - error: "#8b0000"
+      File:
+        title: File
+        description: "File checked by rclone"
+      Priority:
+        title: Priority
+        hidden: true
     pconfig:
       no_violin: true
+      defaultsort:
+        - column: Priority
+          direction: asc
 
   rclone_check:
     section_name: "Source-Destination Checksum Validation"
     description: "Comparison of the checksums of corresponding file(s) in the source input path and the output destination to confirm data integrity following file transfer."
     plot_type: "table"
     file_format: "tsv"
+    headers:
+      Status:
+        title: Result
+        description: "= Match; - Missing in source; + Missing in destination; * Mismatch; ! Error"
+        cond_formatting_rules:
+          match:
+            - s_eq: "="
+            - s_eq: "Match"
+          missing_source:
+            - s_eq: "-"
+            - s_eq: "Missing in source"
+          missing_destination:
+            - s_eq: "+"
+            - s_eq: "Missing in destination"
+          mismatch:
+            - s_eq: "*"
+            - s_eq: "Mismatch"
+          error:
+            - s_eq: "!"
+            - s_eq: "Error"
+        cond_formatting_colours:
+          - match: "#5cb85c"
+          - missing_source: "#f0ad4e"
+          - missing_destination: "#5bc0de"
+          - mismatch: "#d9534f"
+          - error: "#8b0000"
+      File:
+        title: File
+        description: "File checked by rclone"
+      Priority:
+        title: Priority
+        hidden: true
     pconfig:
       no_violin: true
+      defaultsort:
+        - column: Priority
+          direction: asc
 
 sp:
   samplesheet:

--- a/assets/multiqc_custom.css
+++ b/assets/multiqc_custom.css
@@ -1,0 +1,33 @@
+/* Keep the internal row identifier available to MultiQC without displaying it. */
+#rclone_checksum_md5-section-plot_table .rowheader,
+#rclone_checksum_sha-section-plot_table .rowheader,
+#rclone_check-section-plot_table .rowheader {
+  display: none;
+}
+
+/* Fit rclone result tables to the report width and wrap long file paths. */
+#rclone_checksum_md5-section-plot_table,
+#rclone_checksum_sha-section-plot_table,
+#rclone_check-section-plot_table {
+  table-layout: fixed;
+  width: 100%;
+}
+
+#rclone_checksum_md5-section-plot_table .Status,
+#rclone_checksum_sha-section-plot_table .Status,
+#rclone_check-section-plot_table .Status {
+  width: 14rem;
+}
+
+#rclone_checksum_md5-section-plot_table .File .val,
+#rclone_checksum_sha-section-plot_table .File .val,
+#rclone_check-section-plot_table .File .val {
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+#rclone_checksum_md5-section-plot_table_container .mqc-table-responsive,
+#rclone_checksum_sha-section-plot_table_container .mqc-table-responsive,
+#rclone_check-section-plot_table_container .mqc-table-responsive {
+  overflow-x: hidden;
+}

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -46,7 +46,13 @@ process {
     }
 
     withName: 'MULTIQC' {
-        ext.args   = { params.multiqc_title ? "--title \"$params.multiqc_title\"" : '' }
+        ext.args = {
+            def args = ['--custom-css-file */multiqc_custom.css']
+            if (params.multiqc_title) {
+                args.add("--title \"$params.multiqc_title\"")
+            }
+            args.join(' ')
+        }
         publishDir = [
             path: { "${params.outdir}/multiqc" },
             mode: params.publish_dir_mode,

--- a/subworkflows/local/utils_nfcore_datasync_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_datasync_pipeline/main.nf
@@ -183,14 +183,22 @@ def parseRcloneCheck(meta, check_file) {
         '*': 'Mismatch',
         '!': 'Error'
     ]
+    def priority_map = [
+        '!': 0,
+        '*': 1,
+        '-': 2,
+        '+': 3,
+        '=': 4
+    ]
 
     return check_file.readLines()
         .findAll { it.trim() }
         .collect { line ->
             def fields = line.split(/ /, 2)
             def status = status_map.get(fields[0], fields[0])
+            def priority = priority_map.get(fields[0], 0)
 
-            [ meta, "${fields[1]}\t${meta.id}\t${status}\n" ]
+            [ meta, "${fields[1]}\t${meta.id}\t${status}\t${fields[1]}\t${priority}\n" ]
         }
 }
 

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -56,15 +56,15 @@
             ],
             [
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
-                "multiqc_rclone_check.txt:md5,b6ea8bb50b08e6a31b02de80f15cba83",
-                "multiqc_rclone_checksum_md5.txt:md5,b6ea8bb50b08e6a31b02de80f15cba83",
+                "multiqc_rclone_check.txt:md5,33c4b2d611ba070825a845a089546e76",
+                "multiqc_rclone_checksum_md5.txt:md5,33c4b2d611ba070825a845a089546e76",
                 "multiqc_samplesheet.txt:md5,608c07d7a768f3d66b44f8daddcec95e"
             ]
         ],
-        "timestamp": "2026-07-16T18:16:30.402815144",
+        "timestamp": "2026-07-17T16:46:31.424092166",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/tests/main_full.nf.test.snap
+++ b/tests/main_full.nf.test.snap
@@ -43,16 +43,16 @@
             ],
             [
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
-                "multiqc_rclone_check.txt:md5,034d1d633f567288c33f2c5e2b917962",
-                "multiqc_rclone_checksum_md5.txt:md5,dda2aa574568eb99f579fca2a1b19207",
-                "multiqc_rclone_checksum_sha.txt:md5,034d1d633f567288c33f2c5e2b917962",
+                "multiqc_rclone_check.txt:md5,6ee1b24af2769c0620cb6a3c52d7e3ce",
+                "multiqc_rclone_checksum_md5.txt:md5,0367be35c8af1775ccedaac24abdbfa9",
+                "multiqc_rclone_checksum_sha.txt:md5,6ee1b24af2769c0620cb6a3c52d7e3ce",
                 "multiqc_samplesheet.txt:md5,00788a52d1a014c12ac4ed554b0b44ca"
             ]
         ],
-        "timestamp": "2026-07-16T18:18:10.503592311",
+        "timestamp": "2026-07-17T16:51:02.615492867",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/workflows/datasync.nf
+++ b/workflows/datasync.nf
@@ -74,7 +74,7 @@ workflow DATASYNC {
             parseRcloneCheck(meta, check_file)
         }
         .collectFile(
-            seed: "File\tSample\tStatus\n",
+            seed: "Row\tSample\tStatus\tFile\tPriority\n",
             sort: false
         ) { meta, checksum ->
             return [ "${meta.id}_${meta.check_format}_rclone_checksum_mqc.tsv", checksum ]
@@ -106,7 +106,7 @@ workflow DATASYNC {
             parseRcloneCheck(meta, check_file)
         }
         .collectFile(
-            seed: "File\tSample\tStatus\n",
+            seed: "Row\tSample\tStatus\tFile\tPriority\n",
             sort: false
         ) { meta, check ->
             return [ "${meta.id}_rclone_check_mqc.tsv", check ]
@@ -155,6 +155,7 @@ workflow DATASYNC {
         : file("${projectDir}/assets/methods_description_template.yml", checkIfExists: true)
     def ch_methods_description = channel.value(methodsDescriptionText(ch_multiqc_custom_methods_description))
     ch_multiqc_files = ch_multiqc_files.mix(ch_methods_description.collectFile(name: 'methods_description_mqc.yaml', sort: true))
+    ch_multiqc_files = ch_multiqc_files.mix(channel.value(file("${projectDir}/assets/multiqc_custom.css", checkIfExists: true)))
     MULTIQC(
         ch_multiqc_files.flatten().collect().map { files ->
             [


### PR DESCRIPTION
Cosmetic changes to the multiqc report:
- Add colors to the files that match/mistmatch etc so that it more clearly shows failures.
- Sort rows in the multiqc report by 'priority' order, showing first the files with errors and last the files that match.
- Expand the tables to its full width so that users do not need to scroll.

Example:
<img width="890" height="352" alt="image" src="https://github.com/user-attachments/assets/0a37772d-e529-4d03-87fa-479251cca774" />
