### PR TITLE
Remove `--one-way` from `rclone/checksum` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Initial release of nf-core/datasync, created with the [nf-core](https://nf-co.re
 
 ### `Fixed`
 
+- [[#76](https://github.com/nf-core/datasync/pull/76)] - Remove `--one-way` from rclone/checksum confi ([@delfiterradas](https://github.com/delfiterradas), review by [@atrigila](https://github.com/atrigila) and [@antoniasaracco](https://github.com/antoniasaracco)).
 - [[#73](https://github.com/nf-core/datasync/pull/73)] - Create tmp `files_to_copy.tx` avoiding error with write permissions in work directory ([@delfiterradas](https://github.com/delfiterradas), review by [@atrigila](https://github.com/atrigila) and [@antoniasaracco](https://github.com/antoniasaracco)).
 
 ### `Dependencies`

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -22,8 +22,7 @@ process {
         tag = { "${meta.id}_${hash}" }
         ext.args = {
             def base_args = [
-                '--no-check-certificate',
-                "--one-way"
+                '--no-check-certificate'
             ]
             if (params.download && meta.check_format == 'sha') {
                 base_args.add("--download")

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -45,7 +45,9 @@
                 "rclone/checksum/Illumina_annotation/Illumina_annotation.match.txt",
                 "rclone/checksum/benchmark_bed",
                 "rclone/checksum/benchmark_bed/benchmark_bed.combined.txt",
+                "rclone/checksum/benchmark_bed/benchmark_bed.exit_code.txt",
                 "rclone/checksum/benchmark_bed/benchmark_bed.match.txt",
+                "rclone/checksum/benchmark_bed/benchmark_bed.missing_on_src.txt",
                 "rclone/copy",
                 "rclone/copy/Illumina_annotation-rclone-copy.log",
                 "rclone/copy/benchmark_bed-rclone-copy.log"
@@ -53,11 +55,11 @@
             [
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
                 "multiqc_rclone_check.txt:md5,f9dc48d3c4d35cd7297b0a16227c3bcd",
-                "multiqc_rclone_checksum_md5.txt:md5,f9dc48d3c4d35cd7297b0a16227c3bcd",
+                "multiqc_rclone_checksum_md5.txt:md5,c7127de966d1be295ef6697dba648c79",
                 "multiqc_samplesheet.txt:md5,373d903a41ab29bd26db35a3041626e4"
             ]
         ],
-        "timestamp": "2026-07-22T22:00:27.445840436",
+        "timestamp": "2026-08-05T15:09:10.284238596",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"

--- a/tests/edge.nf.test.snap
+++ b/tests/edge.nf.test.snap
@@ -51,6 +51,7 @@
                 "rclone/checksum/Illumina_annotation_missing/Illumina_annotation_missing.exit_code.txt",
                 "rclone/checksum/Illumina_annotation_missing/Illumina_annotation_missing.match.txt",
                 "rclone/checksum/Illumina_annotation_missing/Illumina_annotation_missing.missing_on_dst.txt",
+                "rclone/checksum/Illumina_annotation_missing/Illumina_annotation_missing.missing_on_src.txt",
                 "rclone/checksum/Illumina_annotation_sha_only",
                 "rclone/checksum/Illumina_annotation_sha_only/Illumina_annotation_sha_only.combined.txt",
                 "rclone/checksum/Illumina_annotation_sha_only/Illumina_annotation_sha_only.differ.txt",
@@ -62,12 +63,12 @@
             [
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
                 "multiqc_rclone_check.txt:md5,4b2a6990836593f69e8e81a82c3daf42",
-                "multiqc_rclone_checksum_md5.txt:md5,cf92203df21f04ddf8315fc606812e0b",
+                "multiqc_rclone_checksum_md5.txt:md5,40ef26b67a9f5c4943a12d412f4e632f",
                 "multiqc_rclone_checksum_sha.txt:md5,8d38305a4ad03c7ea18aa9827d34a396",
                 "multiqc_samplesheet.txt:md5,bbfc817ff43c49cde14a2b33f46b5ae5"
             ]
         ],
-        "timestamp": "2026-07-30T20:44:41.242808343",
+        "timestamp": "2026-08-05T15:10:18.931695751",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"
@@ -128,6 +129,7 @@
                 "rclone/checksum/Illumina_annotation_missing/Illumina_annotation_missing.exit_code.txt",
                 "rclone/checksum/Illumina_annotation_missing/Illumina_annotation_missing.match.txt",
                 "rclone/checksum/Illumina_annotation_missing/Illumina_annotation_missing.missing_on_dst.txt",
+                "rclone/checksum/Illumina_annotation_missing/Illumina_annotation_missing.missing_on_src.txt",
                 "rclone/checksum/Illumina_annotation_sha_only",
                 "rclone/checksum/Illumina_annotation_sha_only/Illumina_annotation_sha_only.combined.txt",
                 "rclone/checksum/Illumina_annotation_sha_only/Illumina_annotation_sha_only.differ.txt",
@@ -140,12 +142,12 @@
             [
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
                 "multiqc_rclone_check.txt:md5,c8f13c10aa4f0e4b356c5c08a9ae7ee9",
-                "multiqc_rclone_checksum_md5.txt:md5,cf92203df21f04ddf8315fc606812e0b",
+                "multiqc_rclone_checksum_md5.txt:md5,40ef26b67a9f5c4943a12d412f4e632f",
                 "multiqc_rclone_checksum_sha.txt:md5,8d38305a4ad03c7ea18aa9827d34a396",
                 "multiqc_samplesheet.txt:md5,bbfc817ff43c49cde14a2b33f46b5ae5"
             ]
         ],
-        "timestamp": "2026-07-30T20:44:11.000298059",
+        "timestamp": "2026-08-05T15:09:41.763856779",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"

--- a/tests/main_full.nf.test.snap
+++ b/tests/main_full.nf.test.snap
@@ -40,19 +40,21 @@
                 "rclone/checksum",
                 "rclone/checksum/demultiplex",
                 "rclone/checksum/demultiplex/demultiplex.combined.txt",
+                "rclone/checksum/demultiplex/demultiplex.exit_code.txt",
                 "rclone/checksum/demultiplex/demultiplex.match.txt",
+                "rclone/checksum/demultiplex/demultiplex.missing_on_src.txt",
                 "rclone/copy",
                 "rclone/copy/demultiplex-rclone-copy.log"
             ],
             [
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
                 "multiqc_rclone_check.txt:md5,03a73f087a286ec6580aada2a5db2e7c",
-                "multiqc_rclone_checksum_md5.txt:md5,d7c7dd71a9ff75955dd0e508d1ad9968",
+                "multiqc_rclone_checksum_md5.txt:md5,a68bd0275b5b6cb62ec966b68121b0e1",
                 "multiqc_rclone_checksum_sha.txt:md5,03a73f087a286ec6580aada2a5db2e7c",
                 "multiqc_samplesheet.txt:md5,00788a52d1a014c12ac4ed554b0b44ca"
             ]
         ],
-        "timestamp": "2026-07-30T20:46:20.306063412",
+        "timestamp": "2026-08-05T15:12:45.951559208",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"


### PR DESCRIPTION
Rclone checksum should check if any files are present in source but not in checksum file

<!--
# nf-core/datasync pull request

Many thanks for contributing to nf-core/datasync!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/datasync/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/datasync/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/datasync _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
